### PR TITLE
결제 승인 에러 핸들링 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.internal.impldep.org.junit.platform.launcher.TagFilter.excludeTags
+
 plugins {
     kotlin("jvm") version "1.9.24"
     kotlin("plugin.spring") version "1.9.24"
@@ -42,5 +44,7 @@ kotlin {
 }
 
 tasks.withType<Test> {
-    useJUnitPlatform()
+    useJUnitPlatform{
+        excludeTags ("TooLongTime")
+    }
 }

--- a/src/main/kotlin/com/example/paymentservice/payment/adapter/out/web/toss/exception/PSPConfirmationException.kt
+++ b/src/main/kotlin/com/example/paymentservice/payment/adapter/out/web/toss/exception/PSPConfirmationException.kt
@@ -1,0 +1,28 @@
+package com.example.paymentservice.payment.adapter.out.web.toss.exception
+
+import com.example.paymentservice.payment.domain.PaymentStatus
+
+class PSPConfirmationException (
+    val errorCode: String,
+    val errorMessage: String,
+    val isSuccess: Boolean,
+    val isFailure: Boolean,
+    val isUnknown: Boolean,
+    val isRetryableError: Boolean,
+    cause: Throwable? = null
+) : RuntimeException(errorMessage, cause) {
+    init {
+        require(isSuccess || isFailure || isUnknown) {
+            "${this::class.simpleName} 는 올바르지 않은 결제 상태를 가지고 있습니다."
+        }
+    }
+
+    fun paymentStatus(): PaymentStatus {
+        return when {
+            isSuccess -> PaymentStatus.SUCCESS
+            isFailure -> PaymentStatus.FAILURE
+            isUnknown -> PaymentStatus.UNKNOWN
+            else -> error("${this::class.simpleName} 는 올바르지 않은 결제 상태를 가지고 있습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/example/paymentservice/payment/adapter/out/web/toss/exception/TossPaymentError.kt
+++ b/src/main/kotlin/com/example/paymentservice/payment/adapter/out/web/toss/exception/TossPaymentError.kt
@@ -1,0 +1,85 @@
+package com.example.paymentservice.payment.adapter.out.web.toss.exception
+
+enum class TossPaymentError(val statusCode: Int, val description: String){
+    ALREADY_PROCESSED_PAYMENT(400, "이미 처리된 결제 입니다."),
+    PROVIDER_ERROR(400, "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    EXCEED_MAX_CARD_INSTALLMENT_PLAN(400, "설정 가능한 최대 할부 개월 수를 초과했습니다."),
+    INVALID_REQUEST(400, "잘못된 요청입니다."),
+    NOT_ALLOWED_POINT_USE(400, "포인트 사용이 불가한 카드로 카드 포인트 결제에 실패했습니다."),
+    INVALID_API_KEY(400, "잘못된 시크릿키 연동 정보 입니다."),
+    INVALID_REJECT_CARD(400, "카드 사용이 거절되었습니다. 카드사 문의가 필요합니다."),
+    BELOW_MINIMUM_AMOUNT(400, "신용카드는 결제금액이 100원 이상, 계좌는 200원이상부터 결제가 가능합니다."),
+    INVALID_CARD_EXPIRATION(400, "카드 정보를 다시 확인해주세요. (유효기간)"),
+    INVALID_STOPPED_CARD(400, "정지된 카드 입니다."),
+    EXCEED_MAX_DAILY_PAYMENT_COUNT(400, "하루 결제 가능 횟수를 초과했습니다."),
+    NOT_SUPPORTED_INSTALLMENT_PLAN_CARD_OR_MERCHANT(400, "할부가 지원되지 않는 카드 또는 가맹점 입니다."),
+    INVALID_CARD_INSTALLMENT_PLAN(400, "할부 개월 정보가 잘못되었습니다."),
+    NOT_SUPPORTED_MONTHLY_INSTALLMENT_PLAN(400, "할부가 지원되지 않는 카드입니다."),
+    EXCEED_MAX_PAYMENT_AMOUNT(400, "하루 결제 가능 금액을 초과했습니다."),
+    NOT_FOUND_TERMINAL_ID(400, "단말기번호(Terminal Id)가 없습니다. 토스페이먼츠로 문의 바랍니다."),
+    INVALID_AUTHORIZE_AUTH(400, "유효하지 않은 인증 방식입니다."),
+    INVALID_CARD_LOST_OR_STOLEN(400, "분실 혹은 도난 카드입니다."),
+    RESTRICTED_TRANSFER_ACCOUNT(400, "계좌는 등록 후 12시간 뒤부터 결제할 수 있습니다. 관련 정책은 해당 은행으로 문의해주세요."),
+    INVALID_CARD_NUMBER(400, "카드번호를 다시 확인해주세요."),
+    INVALID_UNREGISTERED_SUBMALL(400, "등록되지 않은 서브몰입니다. 서브몰이 없는 가맹점이라면 안심클릭이나 ISP 결제가 필요합니다."),
+    NOT_REGISTERED_BUSINESS(400, "등록되지 않은 사업자 번호입니다."),
+    EXCEED_MAX_ONE_DAY_WITHDRAW_AMOUNT(400, "1일 출금 한도를 초과했습니다."),
+    EXCEED_MAX_ONE_TIME_WITHDRAW_AMOUNT(400, "1회 출금 한도를 초과했습니다."),
+    CARD_PROCESSING_ERROR(400, "카드사에서 오류가 발생했습니다."),
+    EXCEED_MAX_AMOUNT(400, "거래금액 한도를 초과했습니다."),
+    INVALID_ACCOUNT_INFO_RE_REGISTER(400, "유효하지 않은 계좌입니다. 계좌 재등록 후 시도해주세요."),
+    NOT_AVAILABLE_PAYMENT(400, "결제가 불가능한 시간대입니다"),
+    UNAPPROVED_ORDER_ID(400, "아직 승인되지 않은 주문번호입니다."),
+    UNAUTHORIZED_KEY(401, "인증되지 않은 시크릿 키 혹은 클라이언트 키 입니다."),
+    REJECT_ACCOUNT_PAYMENT(403, "잔액부족으로 결제에 실패했습니다."),
+    REJECT_CARD_PAYMENT(403, "한도초과 혹은 잔액부족으로 결제에 실패했습니다."),
+    REJECT_CARD_COMPANY(403, "결제 승인이 거절되었습니다."),
+    FORBIDDEN_REQUEST(403, "허용되지 않은 요청입니다."),
+    REJECT_TOSSPAY_INVALID_ACCOUNT(403, "선택하신 출금 계좌가 출금이체 등록이 되어 있지 않아요. 계좌를 다시 등록해 주세요."),
+    EXCEED_MAX_AUTH_COUNT(403, "최대 인증 횟수를 초과했습니다. 카드사로 문의해주세요."),
+    EXCEED_MAX_ONE_DAY_AMOUNT(403, "일일 한도를 초과했습니다."),
+    NOT_AVAILABLE_BANK(403, "은행 서비스 시간이 아닙니다."),
+    INVALID_PASSWORD(403, "결제 비밀번호가 일치하지 않습니다."),
+    INCORRECT_BASIC_AUTH_FORMAT(403, "잘못된 요청입니다. ':' 를 포함해 인코딩해주세요."),
+    FDS_ERROR(403, "[토스페이먼츠] 위험거래가 감지되어 결제가 제한됩니다. 발송된 문자에 포함된 링크를 통해 본인인증 후 결제가 가능합니다. (고객센터: 1644-8051)"),
+    NOT_FOUND_PAYMENT(404, "존재하지 않는 결제 정보 입니다."),
+    NOT_FOUND_PAYMENT_SESSION(404, "결제 시간이 만료되어 결제 진행 데이터가 존재하지 않습니다."),
+    FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING(500, "결제가 완료되지 않았어요. 다시 시도해주세요."),
+    FAILED_INTERNAL_SYSTEM_PROCESSING(500, "내부 시스템 처리 작업이 실패했습니다. 잠시 후 다시 시도해주세요."),
+    UNKNOWN_PAYMENT_ERROR(500, "결제에 실패했어요. 같은 문제가 반복된다면 은행이나 카드사로 문의해주세요."),
+    UNKNOWN(500, "알 수 없는 에러입니다.");
+
+    fun isSuccess(): Boolean {
+        return when (this) {
+            ALREADY_PROCESSED_PAYMENT -> true
+            else -> false
+        }
+    }
+
+    fun isFailure(): Boolean {
+        return when (this) {
+            ALREADY_PROCESSED_PAYMENT,
+            UNKNOWN,
+            UNKNOWN_PAYMENT_ERROR,
+            PROVIDER_ERROR,
+            CARD_PROCESSING_ERROR,
+            FAILED_INTERNAL_SYSTEM_PROCESSING,
+            FAILED_PAYMENT_INTERNAL_SYSTEM_PROCESSING -> false
+            else -> true
+        }
+    }
+
+    fun isUnknown(): Boolean {
+        return isSuccess().not() && isFailure().not()
+    }
+
+    fun isRetryableError(): Boolean {
+        return isUnknown()
+    }
+
+    companion object {
+        fun get(errorCode: String): TossPaymentError {
+            return entries.find { it.name == errorCode } ?: UNKNOWN
+        }
+    }
+}

--- a/src/main/kotlin/com/example/paymentservice/payment/adapter/out/web/toss/executer/TossPaymentExecutor.kt
+++ b/src/main/kotlin/com/example/paymentservice/payment/adapter/out/web/toss/executer/TossPaymentExecutor.kt
@@ -1,13 +1,20 @@
 package com.example.paymentservice.payment.adapter.out.web.toss.executer
 
 import com.example.paymentservice.payment.adapter.`in`.web.request.TossPaymentConfirmRequest
+import com.example.paymentservice.payment.adapter.out.web.toss.exception.PSPConfirmationException
+import com.example.paymentservice.payment.adapter.out.web.toss.exception.TossPaymentError
 import com.example.paymentservice.payment.adapter.out.web.toss.response.TossPaymentConfirmationResponse
+import com.example.paymentservice.payment.adapter.out.web.toss.response.tossFailureResponse
 import com.example.paymentservice.payment.application.port.`in`.PaymentConfirmCommand
 import com.example.paymentservice.payment.domain.*
+import io.netty.handler.timeout.TimeoutException
+import org.springframework.http.HttpStatusCode
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
+import reactor.util.retry.Retry
+import java.time.Duration
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -35,6 +42,21 @@ class TossPaymentExecutor (
                 }
             """.trimIndent())
             .retrieve()
+            .onStatus({ statusCode: HttpStatusCode -> statusCode.is4xxClientError || statusCode.is5xxServerError }) {
+                response -> response.bodyToMono(tossFailureResponse::class.java)
+                    .flatMap {
+                        val error = TossPaymentError.get(it.code)
+                        Mono.error<PSPConfirmationException>(
+                            PSPConfirmationException(
+                                errorCode = error.name,
+                                errorMessage = error.description,
+                                isSuccess = error.isSuccess(),
+                                isFailure = error.isFailure(),
+                                isUnknown = error.isUnknown(),
+                                isRetryableError = error.isRetryableError())
+                        )
+                    }
+            }
             .bodyToMono(TossPaymentConfirmationResponse::class.java)
              .map {
                  PaymentExecutionResult(
@@ -55,6 +77,13 @@ class TossPaymentExecutor (
                         isRetryable = false
                  )
              }
+             .retryWhen(Retry.backoff(2, Duration.ofSeconds(1)).jitter(0.1)
+                 .filter { it is PSPConfirmationException && it.isRetryableError || it is TimeoutException }
+                 .onRetryExhaustedThrow{ _, retrySignal ->
+                     retrySignal.failure() as PSPConfirmationException
+
+                 }
+             )
     }
 
 }

--- a/src/main/kotlin/com/example/paymentservice/payment/adapter/out/web/toss/response/TossPaymentConfirmationResponse.kt
+++ b/src/main/kotlin/com/example/paymentservice/payment/adapter/out/web/toss/response/TossPaymentConfirmationResponse.kt
@@ -31,7 +31,7 @@ data class TossPaymentConfirmationResponse (
     val checkout: Checkout?,
     val easyPay: EasyPay?,
     val country: String,
-    val failure: TossFailureResponse?,
+    val failure: tossFailureResponse?,
     val cashReceipt: CashReceipt?,
     val cashReceipts: List<CashReceipt>?,
     val discount: Discount?
@@ -108,7 +108,7 @@ data class EasyPay(
     val discountAmount: Int
 )
 
-data class TossFailureResponse(
+data class tossFailureResponse(
     val code: String,
     val message: String
 )

--- a/src/main/kotlin/com/example/paymentservice/payment/application/port/out/PaymentStatusUpdateCommand.kt
+++ b/src/main/kotlin/com/example/paymentservice/payment/application/port/out/PaymentStatusUpdateCommand.kt
@@ -1,7 +1,7 @@
 package com.example.paymentservice.payment.application.port.out
 
-import com.example.paymentservice.payment.domain.PaymentExecutionFailure
 import com.example.paymentservice.payment.domain.PaymentExtraDetails
+import com.example.paymentservice.payment.domain.PaymentFailure
 import com.example.paymentservice.payment.domain.PaymentStatus
 
 data class PaymentStatusUpdateCommand (
@@ -9,7 +9,7 @@ data class PaymentStatusUpdateCommand (
     val orderId: String,
     val status: PaymentStatus,
     val extraDetails: PaymentExtraDetails? = null,
-    val failure: PaymentExecutionFailure? = null,
+    val failure: PaymentFailure? = null,
 
 ){
 

--- a/src/main/kotlin/com/example/paymentservice/payment/application/service/PaymentErrorHandler.kt
+++ b/src/main/kotlin/com/example/paymentservice/payment/application/service/PaymentErrorHandler.kt
@@ -1,0 +1,40 @@
+package com.example.paymentservice.payment.application.service
+
+import com.example.paymentservice.payment.adapter.out.persistent.exception.PaymentAlreadyProcessedException
+import com.example.paymentservice.payment.adapter.out.persistent.exception.PaymentValidationException
+import com.example.paymentservice.payment.adapter.out.web.toss.exception.PSPConfirmationException
+import com.example.paymentservice.payment.application.port.`in`.PaymentConfirmCommand
+import com.example.paymentservice.payment.application.port.out.PaymentStatusUpdateCommand
+import com.example.paymentservice.payment.application.port.out.PaymentStatusUpdatePort
+import com.example.paymentservice.payment.domain.PaymentConfirmationResult
+import com.example.paymentservice.payment.domain.PaymentFailure
+import com.example.paymentservice.payment.domain.PaymentStatus
+import io.netty.handler.timeout.TimeoutException
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Mono
+
+@Service
+class PaymentErrorHandler (
+    private val paymentStatusUpdatePort: PaymentStatusUpdatePort
+) {
+
+    fun handlePaymentConfirmationError(error: Throwable, command: PaymentConfirmCommand): Mono<PaymentConfirmationResult> {
+        val (status, failure) = when (error) {
+            is PSPConfirmationException -> Pair(error.paymentStatus(), PaymentFailure(error.errorCode, error.errorMessage))
+            is PaymentValidationException -> Pair(PaymentStatus.FAILURE, PaymentFailure(error::class.simpleName ?: "", error.message ?: ""))
+            is PaymentAlreadyProcessedException -> return Mono.just(PaymentConfirmationResult(status = error.status, failure = PaymentFailure(message = error.message ?: "", errorCode = error::class.simpleName ?: "")))
+            is TimeoutException -> Pair(PaymentStatus.UNKNOWN, PaymentFailure(error::class.simpleName ?: "", error.message ?: ""))
+            else -> Pair(PaymentStatus.UNKNOWN, PaymentFailure(error::class.simpleName ?: "",  error.message ?: ""))
+        }
+
+        val paymentStatusUpdateCommand = PaymentStatusUpdateCommand(
+            paymentKey = command.paymentKey,
+            orderId = command.orderId,
+            status = status,
+            failure = failure
+        )
+
+        return paymentStatusUpdatePort.updatePaymentStatus(paymentStatusUpdateCommand)
+            .map { PaymentConfirmationResult(status, failure) }
+    }
+}

--- a/src/main/kotlin/com/example/paymentservice/payment/domain/PaymentConfirmationResult.kt
+++ b/src/main/kotlin/com/example/paymentservice/payment/domain/PaymentConfirmationResult.kt
@@ -1,11 +1,9 @@
 package com.example.paymentservice.payment.domain
 
-import java.time.LocalDateTime
-
 
 data class PaymentConfirmationResult(
     val status: PaymentStatus,
-    val failure: PaymentExecutionFailure? = null
+    val failure: PaymentFailure? = null
 )
 {
     init {

--- a/src/main/kotlin/com/example/paymentservice/payment/domain/PaymentExecutionResult.kt
+++ b/src/main/kotlin/com/example/paymentservice/payment/domain/PaymentExecutionResult.kt
@@ -6,7 +6,7 @@ data class PaymentExecutionResult (
     val paymentKey: String,
     val orderId: String,
     val extraDetails: PaymentExtraDetails? = null,
-    val failure: PaymentExecutionFailure? = null,
+    val failure: PaymentFailure? = null,
     val isSuccess: Boolean,
     val isFailure: Boolean,
     val isUnknown: Boolean,
@@ -39,7 +39,3 @@ data class PaymentExtraDetails (
     val pspRawData: String
 )
 
-data class PaymentExecutionFailure (
-    val errorCode: String,
-    val message: String
-)

--- a/src/main/kotlin/com/example/paymentservice/payment/domain/PaymentFailure.kt
+++ b/src/main/kotlin/com/example/paymentservice/payment/domain/PaymentFailure.kt
@@ -1,0 +1,7 @@
+package com.example.paymentservice.payment.domain
+
+class PaymentFailure(
+    val errorCode: String,
+    val message: String
+) {
+}

--- a/src/test/kotlin/com/example/paymentservice/payment/adapter/out/web/toss/executer/TossPaymentExecutorTest.kt
+++ b/src/test/kotlin/com/example/paymentservice/payment/adapter/out/web/toss/executer/TossPaymentExecutorTest.kt
@@ -1,0 +1,70 @@
+package com.example.paymentservice.payment.adapter.out.web.toss.executer
+
+import com.example.paymentservice.payment.adapter.out.web.toss.exception.PSPConfirmationException
+import com.example.paymentservice.payment.adapter.out.web.toss.exception.TossPaymentError
+import com.example.paymentservice.payment.application.port.`in`.PaymentConfirmCommand
+import com.example.paymentservice.payment.test.PSPTestWebClientConfiguration
+import com.example.paymentservice.payment.test.PaymentTestConfiguration
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import java.util.*
+
+
+@SpringBootTest
+@Import(PSPTestWebClientConfiguration::class)
+@Tag("TooLongTime")
+class TossPaymentExecutorTest(
+    @Autowired private val pspTestWebClientConfiguration: PSPTestWebClientConfiguration
+)
+{
+
+    @Test
+    fun `should handle correctly various TossPaymentError scenarios`()
+    {
+       generateErrorScenarios().forEach { errorScenario ->
+           val command = PaymentConfirmCommand(
+               paymentKey = UUID.randomUUID().toString(),
+               orderId = UUID.randomUUID().toString(),
+               amount = 10000L
+           )
+
+           val paymentExecutor = TossPaymentExecutor(
+               tossPaymentWebClient = pspTestWebClientConfiguration.createTestTossWebClient(
+                   Pair("TossPayments-Test-Code", errorScenario.errorCode)
+               ),
+               uri = "/v1/payments/key-in"
+           )
+
+              try {
+                paymentExecutor.execute(command).block()
+              } catch (e: PSPConfirmationException) {
+                assertThat(e.isSuccess).isEqualTo(errorScenario.isSuccess)
+                assertThat(e.isFailure).isEqualTo(errorScenario.isFailure)
+                assertThat(e.isUnknown).isEqualTo(errorScenario.isUnknown)
+              }
+       }
+    }
+
+    private fun generateErrorScenarios(): List<ErrorScenario> {
+        return TossPaymentError.entries.map { error ->
+            ErrorScenario(
+                errorCode = error.name,
+                isSuccess = error.isSuccess(),
+                isFailure = error.isFailure(),
+                isUnknown = error.isUnknown()
+            )
+        }
+    }
+
+}
+
+data class ErrorScenario(
+    val errorCode: String,
+    val isFailure: Boolean,
+    val isUnknown: Boolean,
+    val isSuccess: Boolean
+)

--- a/src/test/kotlin/com/example/paymentservice/payment/application/service/PaymentConfirmServiceTest.kt
+++ b/src/test/kotlin/com/example/paymentservice/payment/application/service/PaymentConfirmServiceTest.kt
@@ -1,5 +1,8 @@
 package com.example.paymentservice.payment.application.service
 
+import com.example.paymentservice.payment.adapter.out.persistent.exception.PaymentValidationException
+import com.example.paymentservice.payment.adapter.out.web.toss.exception.PSPConfirmationException
+import com.example.paymentservice.payment.adapter.out.web.toss.exception.TossPaymentError
 import com.example.paymentservice.payment.application.port.`in`.CheckoutCommand
 import com.example.paymentservice.payment.application.port.`in`.CheckoutUseCase
 import com.example.paymentservice.payment.application.port.`in`.PaymentConfirmCommand
@@ -15,6 +18,7 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -33,6 +37,7 @@ class PaymentConfirmServiceTest(
     @Autowired private val paymentStatusUpdatePort: PaymentStatusUpdatePort,
     @Autowired private val paymentValidationPort: PaymentValidationPort,
     @Autowired private val paymentDatabaseHelper: PaymentDatabaseHelper,
+    @Autowired private val paymentErrorHandler: PaymentErrorHandler
 ) {
     private val mockPaymentExecutorPort = mockk<PaymentExecutorPort>()
 
@@ -66,6 +71,7 @@ class PaymentConfirmServiceTest(
             paymentStatusUpdatePort = paymentStatusUpdatePort,
             paymentValidationPort = paymentValidationPort,
             paymentExecutorPort = mockPaymentExecutorPort,
+            paymentErrorHandler = paymentErrorHandler
         )
 
         val paymentExecutionResult = PaymentExecutionResult(
@@ -125,6 +131,7 @@ class PaymentConfirmServiceTest(
             paymentStatusUpdatePort = paymentStatusUpdatePort,
             paymentValidationPort = paymentValidationPort,
             paymentExecutorPort = mockPaymentExecutorPort,
+            paymentErrorHandler = paymentErrorHandler
         )
 
         val paymentExecutionResult = PaymentExecutionResult(
@@ -139,7 +146,7 @@ class PaymentConfirmServiceTest(
                 approvedAt = LocalDateTime.now(),
                 pspRawData = "{}"
             ),
-            failure = PaymentExecutionFailure("ERROR", "Test Error"),
+            failure = PaymentFailure("ERROR", "Test Error"),
             isSuccess = false,
             isRetryable = false,
             isUnknown = false,
@@ -155,4 +162,199 @@ class PaymentConfirmServiceTest(
         assertThat(paymentConfirmationResult.status).isEqualTo(PaymentStatus.FAILURE)
         assertTrue(paymentEvent.isFailure())
     }
+
+    @Test
+    fun `should handle PSPConfirmationException`() {
+        val orderId = UUID.randomUUID().toString()
+
+        val checkoutCommand = CheckoutCommand(
+            cartId = 1,
+            buyerId = 1,
+            productIds = listOf(1, 2, 3),
+            idempotencyKey = orderId
+        )
+
+        val checkoutResult = checkoutUseCase.checkout(checkoutCommand).block()!!
+
+        val paymentConfirmCommand = PaymentConfirmCommand(
+            paymentKey = UUID.randomUUID().toString(),
+            orderId = orderId,
+            amount = checkoutResult.amount
+        )
+
+        val paymentConfirmService = PaymentConfirmService(
+            paymentStatusUpdatePort = paymentStatusUpdatePort,
+            paymentValidationPort = paymentValidationPort,
+            paymentExecutorPort = mockPaymentExecutorPort,
+            paymentErrorHandler = paymentErrorHandler
+        )
+
+        val pspConfirmationException = PSPConfirmationException(
+            errorCode = TossPaymentError.REJECT_ACCOUNT_PAYMENT.name,
+            errorMessage = TossPaymentError.REJECT_ACCOUNT_PAYMENT.description,
+            isSuccess = false,
+            isFailure = true,
+            isUnknown = false,
+            isRetryableError = false
+        )
+
+        every { mockPaymentExecutorPort.execute(paymentConfirmCommand) } returns Mono.error(pspConfirmationException)
+
+        val paymentConfirmationResult = paymentConfirmService.confirm(paymentConfirmCommand).block()!!
+        val paymentEvent = paymentDatabaseHelper.getPayments(orderId)!!
+
+        assertThat(paymentConfirmationResult.status).isEqualTo(PaymentStatus.FAILURE)
+        assertTrue(paymentEvent.isFailure())
+    }
+
+    @Test
+    fun `should handle PaymentValidationException`() {
+        val orderId = UUID.randomUUID().toString()
+
+        val checkoutCommand = CheckoutCommand(
+            cartId = 1,
+            buyerId = 1,
+            productIds = listOf(1, 2, 3),
+            idempotencyKey = orderId
+        )
+
+        val checkoutResult = checkoutUseCase.checkout(checkoutCommand).block()!!
+
+        val paymentConfirmCommand = PaymentConfirmCommand(
+            paymentKey = UUID.randomUUID().toString(),
+            orderId = orderId,
+            amount = checkoutResult.amount
+        )
+
+        val mockPaymentValidationPort = mockk<PaymentValidationPort>()
+
+        val paymentConfirmService = PaymentConfirmService(
+            paymentStatusUpdatePort = paymentStatusUpdatePort,
+            paymentExecutorPort = mockPaymentExecutorPort,
+            paymentValidationPort = mockPaymentValidationPort,
+            paymentErrorHandler = paymentErrorHandler
+        )
+
+        val paymentValidationException = PaymentValidationException("결제 유효성 검증에서 실패하였습니다.")
+
+        every { mockPaymentValidationPort.isValid(orderId, paymentConfirmCommand.amount) } returns Mono.error(paymentValidationException)
+
+        val paymentConfirmationResult = paymentConfirmService.confirm(paymentConfirmCommand).block()!!
+        val paymentEvent = paymentDatabaseHelper.getPayments(orderId)!!
+
+        assertThat(paymentConfirmationResult.status).isEqualTo(PaymentStatus.FAILURE)
+        assertTrue(paymentEvent.isFailure())
+    }
+
+    @Test
+    fun `should handle PaymentAlreadyProcessedException`() {
+        val orderId = UUID.randomUUID().toString()
+
+        val checkoutCommand = CheckoutCommand(
+            cartId = 1,
+            buyerId = 1,
+            productIds = listOf(1, 2, 3),
+            idempotencyKey = orderId
+        )
+
+        val checkoutResult = checkoutUseCase.checkout(checkoutCommand).block()!!
+
+        val paymentConfirmCommand = PaymentConfirmCommand(
+            paymentKey = UUID.randomUUID().toString(),
+            orderId = orderId,
+            amount = checkoutResult.amount
+        )
+
+
+        val paymentConfirmService = PaymentConfirmService(
+            paymentStatusUpdatePort = paymentStatusUpdatePort,
+            paymentValidationPort = paymentValidationPort,
+            paymentExecutorPort = mockPaymentExecutorPort,
+            paymentErrorHandler = paymentErrorHandler
+        )
+
+        val paymentExecutionResult = PaymentExecutionResult(
+            paymentKey = paymentConfirmCommand.paymentKey,
+            orderId = paymentConfirmCommand.orderId,
+            extraDetails = PaymentExtraDetails(
+                type = PaymentType.NORMAL,
+                method = PaymentMethod.EASY_PAY,
+                totalAmount = paymentConfirmCommand.amount,
+                orderName = "test_order_name",
+                pspConfirmationStatus = PSPConfirmationStatus.DONE,
+                approvedAt = LocalDateTime.now(),
+                pspRawData = "{}"
+            ),
+            isSuccess = true,
+            isRetryable = false,
+            isUnknown = false,
+            isFailure = false
+        )
+
+        every { mockPaymentExecutorPort.execute(paymentConfirmCommand) } returns Mono.just(paymentExecutionResult)
+
+        paymentConfirmService.confirm(paymentConfirmCommand).block()!!
+        val paymentConfirmationResult = paymentConfirmService.confirm(paymentConfirmCommand).block()!!
+
+        val paymentEvent = paymentDatabaseHelper.getPayments(orderId)!!
+
+        assertThat(paymentConfirmationResult.status).isEqualTo(PaymentStatus.SUCCESS)
+        assertTrue(paymentEvent.paymentOrders.all { it.paymentStatus == PaymentStatus.SUCCESS })
+    }
+
+
+    @Test
+    @Tag("ExternalIntegration")
+    fun `should send the event message to the external message system after the payment confirmation has been successful`() {
+        Hooks.onOperatorDebug()
+
+        val orderId = UUID.randomUUID().toString()
+
+        val checkoutCommand = CheckoutCommand(
+            cartId = 1,
+            buyerId = 1,
+            productIds = listOf(1, 2, 3),
+            idempotencyKey = orderId
+        )
+
+        val checkoutResult = checkoutUseCase.checkout(checkoutCommand).block()!!
+
+        val paymentConfirmCommand = PaymentConfirmCommand(
+            paymentKey = UUID.randomUUID().toString(),
+            orderId = orderId,
+            amount = checkoutResult.amount
+        )
+
+        val paymentConfirmService = PaymentConfirmService(
+            paymentStatusUpdatePort = paymentStatusUpdatePort,
+            paymentValidationPort = paymentValidationPort,
+            paymentExecutorPort = mockPaymentExecutorPort,
+            paymentErrorHandler = paymentErrorHandler
+        )
+
+        val paymentExecutionResult = PaymentExecutionResult(
+            paymentKey = paymentConfirmCommand.paymentKey,
+            orderId = paymentConfirmCommand.orderId,
+            extraDetails = PaymentExtraDetails(
+                type = PaymentType.NORMAL,
+                method = PaymentMethod.EASY_PAY,
+                totalAmount = paymentConfirmCommand.amount,
+                orderName = "test_order_name",
+                pspConfirmationStatus = PSPConfirmationStatus.DONE,
+                approvedAt = LocalDateTime.now(),
+                pspRawData = "{}"
+            ),
+            isSuccess = true,
+            isRetryable = false,
+            isUnknown = false,
+            isFailure = false
+        )
+
+        every { mockPaymentExecutorPort.execute(paymentConfirmCommand) } returns Mono.just(paymentExecutionResult)
+
+        paymentConfirmService.confirm(paymentConfirmCommand).block()!!
+
+        Thread.sleep(10000)
+    }
+
 }

--- a/src/test/kotlin/com/example/paymentservice/payment/test/PSPTestWebClientConfiguration.kt
+++ b/src/test/kotlin/com/example/paymentservice/payment/test/PSPTestWebClientConfiguration.kt
@@ -1,0 +1,37 @@
+package com.example.paymentservice.payment.test
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.client.reactive.ClientHttpConnector
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import reactor.netty.resources.ConnectionProvider
+import java.util.*
+
+
+@TestConfiguration
+class PSPTestWebClientConfiguration (
+    @Value("\${PSP.toss.url}") private val baseUrl: String,
+    @Value("\${PSP.toss.secretKey}") private val secretKey: String
+) {
+
+    fun createTestTossWebClient(vararg customHeaderKeyValue: Pair<String, String>): WebClient {
+        val encodedSecretKey = Base64.getEncoder().encodeToString(("$secretKey:").toByteArray())
+
+        return WebClient.builder()
+            .baseUrl(baseUrl)
+            .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic $encodedSecretKey")
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            .defaultHeaders { httpHeaders ->
+                customHeaderKeyValue.forEach { httpHeaders[it.first] = it.second }
+            }
+            .clientConnector(reactorClientHttpConnector())
+            .build()
+    }
+
+    private fun reactorClientHttpConnector(): ClientHttpConnector {
+        return ReactorClientHttpConnector(HttpClient.create(ConnectionProvider.builder("test-toss-payment").build()))
+    }
+}


### PR DESCRIPTION

## 고려해야할 결제 에러 코드 
[https://docs.tosspayments.com/reference/error-codes#결제-승인](https://docs.tosspayments.com/reference/error-codes#%EA%B2%B0%EC%A0%9C-%EC%8A%B9%EC%9D%B8)


결제 승인과 관련된 에러를 처리할 때 중요한 건 **“재시도 가능 유무”** 이다. 

**“REJECT_ACCOUNT_PAYMENT (잔액 부족)”** 와 같은 에러는 재시도 할 수 없는 명백한 결제 실패 유형 에러지만 **“PROVIDER_ERROR (일시적 오류 발생)”** 와 같은 일시적인 에러는 재시도를 통해서 해결할 수 있음

결제 승인 요청은 멱등성을 보장해서 여러 번 요청을 해도 동일한 응답을 받아올 수 있는 방법도 있다. 요청 헤더에 아래의 멱등성 키-값을 추가하면 된다. 
```
Idempotency-Key: {IDEMPOTENCY_KEY}
```

## 재시도를 잘하는 방법

이전에는 결제 승인 에러를 확인하고 재시도 여부를 결정하는 ‘언제 재시도를 할 수 있는가’ 에 대해서 설명했었다. 그러나 이것 말고도 ‘어떻게 재시도를 하는가’ 도 중요하다. 

재시도를 적용할 때 고려해야 할 사항은 다음과 같다: 

- 지수 백오프(Exponential Backoff)
- 재시도 제한 횟수(Retry Limited Count)
- 지터(Jitter)

**Exponential backoff**:

- 재시도 사이에 일정 시간 지연을 설정하는 것이다. 서버가 과부하로 인해 응답을 전달하지 못하는 경우를 대비해서 일정시간 지연을 주는 것이 필요하다.
- 지연 시간은 재시도마다 지수적으로 증가한다. 예를 들면, 첫 번째 재시도에는 1초 동안 대기하고, 두 번째 재시도에는 2초 대기, 세 번째 재시도에는 4초 대기, 네 번째 재시도에는 8초 이렇게 대기하게된다.

**jitter:**

- 요청이 동시에 재시도 되지 않도록 Expotional backoff 외에 무작위 지연을 추가적으로 부여하는 것이다.
- jitter 이 없다면 요청들이 동시에 재시도 되면서 특정 시간의 주기에만 트래픽이 급증하는 문제가 생길 수 있다. 이 문제에 대해 좀 더 자세하게 설명하자면, 네트워크 요청이나 서버에 대한 쿼리가 실패했을 때, 클라이언트는 일반적으로 연속적인 실패를 방지하고 성공할 때까지 요청을 다시 시도하게 된다. 이때 재시도 간 일정한 간격을 두고 요청을 반복하게 되는데, 만약 많은 클라이언트가 동시에 같은 패턴으로 재시도를 한다면, 서버에 동시에 높은 부하가 발생하여 서버의 성능 저하나 다운타임을 초래할 수 있게 된다.

**Retry Limited Count:**

- 재시도를 수행하는 최대 횟수를 의미한다. 제한 횟수가 설정되어 있지 않으면 무한적으로 재시도하며 자원을 소모할 것이므로 횟수를 지정하는게 중요하다.

## 타임아웃 설정

타임아웃에는 크게 두 가지 유형이 있다. 

- 연결 타임아웃(Connection Timeout): 서버와의 연결을 시도할 때까지의 시간을 말한다.
- 요청 타임아웃(Request Timeout): 요청을 보낸 후 서버로부터 응답을 받기까지의 시간을 말한다.

타임아웃을 설정하지 않으면 서버로부터 응답을 무한히 기다려야 하므로, 이 기간 동안 리소스가 점유되는 문제가 발생한다. 서버를 안전하게 보호하고 리소스를 효율적으로 관리하기 위해서는 타임아웃 설정이 필요하다. 

타임아웃은 얼마로 설정하는 것이 좋을까? 

- 타임아웃을 너무 높게 설정하면 그 시간 동안 리소스가 점유되는 문제가 있다.
- 반면, 타임아웃을 너무 낮게 설정하면 응답이 도착할 가능성이 있는데도 불구하고, 타임아웃으로 인해 응답을 받지 못하는 상황이 발생할 수 있다.

적절한 타임아웃 설정은 사용 환경과 통신하는 API 특성에 따라 달라지는 것이 좋다. 예를 들어, 자신의 서버와 같은 환경에서 네트워크 통신이 많은 다른 서버가 이웃으로 배포되어 있다면 네트워크 대역폭을 고려해 타임아웃을 좀 더 높게 설정해볼 수 있다. 또 통신하는 API 가 복잡한 연산을 요구하고 응답이 오래 걸리는 경우에도 타임아웃을 높게 설정하는 것이 바람직하다.